### PR TITLE
Resolve loading image instead of the template file

### DIFF
--- a/Routes.php
+++ b/Routes.php
@@ -124,6 +124,8 @@ class Routes {
 				add_action('template_redirect', function(){
 					global $wp_query;
 					$wp_query->is_404 = false;
+					$query->is_attachment = false;
+					$query->is_page = true;
 				},1);
 			}
 		}


### PR DESCRIPTION
in the case where the name of one of the parameter is similar to an image within the wp, it would load that first.

the link mysite.com/category/books/ where "books" is a slug of the category, it should redirect me to the detail page of the category.
except there is an image "Books.jpg" within the wp media, in that case it will redirect me to the
mysite.com/wp-content/uploads/2018/09/Books.jpg.