### PR TITLE
Fix parameter type in doc block.

### DIFF
--- a/Routes.php
+++ b/Routes.php
@@ -90,7 +90,7 @@ class Routes {
 	}
 
 	/**
-	 * @param array $template           A php file to load (ex: 'single.php')
+	 * @param string $template           A php file to load (ex: 'single.php')
 	 * @param array|bool $tparams       An array of data to send to the php file. Inside the php file
 	 *                                  this data can be accessed via:
 	 *                                  global $params;


### PR DESCRIPTION
Wrong parameter type causes warnings in IDEs like PHPStorm etc.