### PR TITLE
Add feature to include current route slug in body

### DIFF
--- a/Routes.php
+++ b/Routes.php
@@ -1,155 +1,177 @@
 <?php
 /*
-Plugin Name: Routes
-Plugin URI: http://www.upstatement.com
-Description: Routes makes it easy to add custom routing to your WordPress site. That's why we call it Routes. That is all.
-Author: Jared Novack + Upstatement
-Version: 0.8.1
-Author URI: http://upstatement.com/
+Plugin Name:    Routes
+Plugin URI:     http://www.upstatement.com
+Description:    Routes makes it easy to add custom routing to your WordPress site. That's why we call it Routes. That is all.
+Author:         Jared Novack + Upstatement
+Version:        0.8.2
+Author URI:     https://upstatement.com/
 
 Usage:
 
+```php
 Routes::map('/my-location', function(){
-	//do stuff
+	// do stuff
 	Routes::load('single.php', $data);
 });
+```
 */
 
 class Routes {
-
 	protected $router;
 
-	function __construct(){
-		add_action('init', array($this, 'match_current_request') );
-		add_action('wp_loaded', array($this, 'match_current_request') );
+	function __construct() {
+		add_action( 'init', [ $this, 'match_current_request' ] );
+		add_action( 'wp_loaded', [ $this, 'match_current_request' ] );
 	}
 
 	static function match_current_request() {
 		global $upstatement_routes;
-		if (isset($upstatement_routes->router)) {
+
+		if ( isset( $upstatement_routes->router ) ){
 			$route = $upstatement_routes->router->match();
-			
-			unset($upstatement_routes->router);
-			
-			if ($route && isset($route['target'])) {
-				if ( isset($route['params']) ) {
-					call_user_func($route['target'], $route['params']);
+
+			unset( $upstatement_routes->router );
+
+			if ( $route && isset( $route['target'] ) ){
+				if ( isset( $route['params'] ) ){
+					call_user_func( $route['target'], $route['params'] );
 				} else {
-					call_user_func($route['target']);
+					call_user_func( $route['target'] );
 				}
 			}
 		}
 	}
 
 	/**
-	 * @param string $route         A string to match (ex: 'myfoo')
-	 * @param callable $callback    A function to run, examples:
-	 *                              Routes::map('myfoo', 'my_callback_function');
-	 *                              Routes::map('mybaq', array($my_class, 'method'));
-	 *                              Routes::map('myqux', function() {
-	 *                                  //stuff goes here
-	 *                              });
+	 * @param string   $route             A string to match (ex: 'myfoo')
+	 * @param callable $callback          A function to run, examples:
+	 *                                    Routes::map('myfoo', 'my_callback_function');
+	 *                                    Routes::map('mybaq', array($my_class, 'method'));
+	 *                                    Routes::map('myqux', function() {
+	 *                                    //stuff goes here
+	 *                                    });
+	 * @param array    $args              ...
+	 * @param bool     $add_to_body_class Whether the slug of the current route should be added to the <body> tag
 	 */
-	public static function map($route, $callback, $args = array()) {
+	public static function map( $route, $callback, $args = [], $add_to_body_class = true ) {
 		global $upstatement_routes;
-		if (!isset($upstatement_routes->router)) {
+
+		if ( true === $add_to_body_class ){
+			/** Adds the name or slug of the route to the HTML body tag */
+			add_action( 'init', function ( $classes ) use ( $route ) {
+
+				/** Includes the route page slug in a sanitized form the the <body> ckas */
+				add_filter( 'body_class', function ( $classes ) use ( $route ) {
+					$route = (string) sanitize_title( $route );
+
+					return (array) array_merge( $classes, [ $route ] );
+				} );
+			} );
+		}
+
+		if ( ! isset( $upstatement_routes->router ) ){
 			$upstatement_routes->router = new AltoRouter();
-			$site_url = get_bloginfo('url');
-			$site_url_parts = explode('/', $site_url);
-			$site_url_parts = array_slice($site_url_parts, 3);
-			$base_path = implode('/', $site_url_parts);
-			if (!$base_path || strpos($route, $base_path) === 0) {
+			$site_url                   = get_bloginfo( 'url' );
+			$site_url_parts             = explode( '/', $site_url );
+			$site_url_parts             = array_slice( $site_url_parts, 3 );
+			$base_path                  = implode( '/', $site_url_parts );
+			if ( ! $base_path || strpos( $route, $base_path ) === 0 ){
 				$base_path = '/';
 			} else {
 				$base_path = '/' . $base_path . '/';
 			}
 			// Clean any double slashes that have resulted
 			$base_path = str_replace( "//", "/", $base_path );
-			$upstatement_routes->router->setBasePath($base_path);
+			$upstatement_routes->router->setBasePath( $base_path );
 		}
-		$route = self::convert_route($route);
-		$upstatement_routes->router->map('GET|POST|PUT|DELETE', trailingslashit($route), $callback, $args);
-		$upstatement_routes->router->map('GET|POST|PUT|DELETE', untrailingslashit($route), $callback, $args);
+		$route = self::convert_route( $route );
+		$upstatement_routes->router->map( 'GET|POST|PUT|DELETE', trailingslashit( $route ), $callback, $args );
+		$upstatement_routes->router->map( 'GET|POST|PUT|DELETE', untrailingslashit( $route ), $callback, $args );
 	}
 
 	/**
-	 * @return string 					A string in a format for AltoRouter
-	 *                       			ex: [:my_param]
+	 * @return string                    A string in a format for AltoRouter
+	 *                                ex: [:my_param]
 	 */
-	public static function convert_route($route_string) {
-		if (strpos($route_string, '[') > -1) {
+	public static function convert_route( $route_string ) {
+		if ( strpos( $route_string, '[' ) > -1 ){
 			return $route_string;
 		}
-		$route_string = preg_replace('/(:)\w+/', '/[$0]', $route_string);
-		$route_string = str_replace('[[', '[', $route_string);
-		$route_string = str_replace(']]', ']', $route_string);
-		$route_string = str_replace('[/:', '[:', $route_string);
-		$route_string = str_replace('//[', '/[', $route_string);
-		if ( strpos($route_string, '/') === 0 ) {
-			$route_string = substr($route_string, 1);
+		$route_string = preg_replace( '/(:)\w+/', '/[$0]', $route_string );
+		$route_string = str_replace( '[[', '[', $route_string );
+		$route_string = str_replace( ']]', ']', $route_string );
+		$route_string = str_replace( '[/:', '[:', $route_string );
+		$route_string = str_replace( '//[', '/[', $route_string );
+		if ( strpos( $route_string, '/' ) === 0 ){
+			$route_string = substr( $route_string, 1 );
 		}
 		return $route_string;
 	}
 
 	/**
-	 * @param string $template           A php file to load (ex: 'single.php')
+	 * @param string     $template      A php file to load (ex: 'single.php')
 	 * @param array|bool $tparams       An array of data to send to the php file. Inside the php file
 	 *                                  this data can be accessed via:
 	 *                                  global $params;
-	 * @param int $status_code          A code for the status (ex: 200)
-	 * @param WP_Query $query           Use a WP_Query object in the template file instead of
+	 * @param int        $status_code   A code for the status (ex: 200)
+	 * @param WP_Query   $query         Use a WP_Query object in the template file instead of
 	 *                                  the default query
-	 * @param int $priority		    The priority used by the "template_include" filter
+	 * @param int        $priority      The priority used by the "template_include" filter
+	 *
 	 * @return bool
 	 */
-	public static function load($template, $tparams = false, $query = false, $status_code = 200, $priority = 10) {
-		$fullPath = is_readable($template);
-		if (!$fullPath) {
-			$template = locate_template($template);
+	public static function load( $template, $tparams = false, $query = false, $status_code = 200, $priority = 10 ) {
+		$fullPath = is_readable( $template );
+
+		if ( ! $fullPath ){
+			$template = locate_template( $template );
 		}
-		if ($tparams){
+		if ( $tparams ){
 			global $params;
 			$params = $tparams;
 		}
-		if ($status_code) {
-			add_filter('status_header', function($status_header, $header, $text, $protocol) use ($status_code) {
-				$text = get_status_header_desc($status_code);
+		if ( $status_code ){
+			add_filter( 'status_header', function ( $status_header, $header, $text, $protocol ) use ( $status_code ) {
+				$text          = get_status_header_desc( $status_code );
 				$header_string = "$protocol $status_code $text";
 				return $header_string;
-			}, 10, 4 );
-			if (404 != $status_code) {
-				add_action('parse_query', function($query) {
-					if ($query->is_main_query()){
+			},          10, 4 );
+			if ( 404 != $status_code ){
+				add_action( 'parse_query', function ( $query ) {
+					if ( $query->is_main_query() ){
 						$query->is_404 = false;
 					}
-				},1);
-				add_action('template_redirect', function(){
+				},          1 );
+				add_action( 'template_redirect', function () {
 					global $wp_query;
 					$wp_query->is_404 = false;
-				},1);
+				},          1 );
 			}
 		}
 
-		if ($query) {
-			add_action('do_parse_request', function() use ($query) {
+		if ( $query ){
+			add_action( 'do_parse_request', function () use ( $query ) {
 				global $wp;
-				if ( is_callable($query) )
-					$query = call_user_func($query);
+				if ( is_callable( $query ) ){
+					$query = call_user_func( $query );
+				}
 
-				if ( is_array($query) )
+				if ( is_array( $query ) ){
 					$wp->query_vars = $query;
-				elseif ( !empty($query) )
-					parse_str($query, $wp->query_vars);
-				else
-					return true; // Could not interpret query. Let WP try.
+				} elseif ( ! empty( $query ) ) {
+					parse_str( $query, $wp->query_vars );
+				} else {
+					return true;
+				} // Could not interpret query. Let WP try.
 
 				return false;
-			});
+			} );
 		}
-		if ($template) {
-			add_filter('template_include', function($t) use ($template) {
+		if ( $template ){
+			add_filter( 'template_include', function ( $t ) use ( $template ) {
 				return $template;
-			}, $priority);
+			},          $priority );
 			return true;
 		}
 		return false;
@@ -159,8 +181,8 @@ class Routes {
 global $upstatement_routes;
 $upstatement_routes = new Routes();
 
-if (    file_exists($composer_autoload = __DIR__ . '/vendor/autoload.php')
-		|| file_exists($composer_autoload = WP_CONTENT_DIR.'/vendor/autoload.php')){
-  require_once($composer_autoload);
+if ( file_exists( $composer_autoload = __DIR__ . '/vendor/autoload.php' )
+     || file_exists( $composer_autoload = WP_CONTENT_DIR . '/vendor/autoload.php' ) ){
+	require_once( $composer_autoload );
 }
 

--- a/Routes.php
+++ b/Routes.php
@@ -1,23 +1,22 @@
 <?php
 /*
-Plugin Name:    Routes
-Plugin URI:     http://www.upstatement.com
-Description:    Routes makes it easy to add custom routing to your WordPress site. That's why we call it Routes. That is all.
-Author:         Jared Novack + Upstatement
-Version:        0.8.2
-Author URI:     https://upstatement.com/
+Plugin Name: Routes
+Plugin URI: http://www.upstatement.com
+Description: Routes makes it easy to add custom routing to your WordPress site. That's why we call it Routes. That is all.
+Author: Jared Novack + Upstatement
+Version: 0.8.2
+Author URI: http://upstatement.com/
 
 Usage:
 
-```php
 Routes::map('/my-location', function(){
-	// do stuff
-	Routes::load('single.php', $data);
+    //do stuff
+    Routes::load('single.php', $data);
 });
-```
 */
 
 class Routes {
+
 	protected $router;
 
 	function __construct() {
@@ -27,14 +26,13 @@ class Routes {
 
 	static function match_current_request() {
 		global $upstatement_routes;
-
-		if ( isset( $upstatement_routes->router ) ){
+		if ( isset( $upstatement_routes->router ) ) {
 			$route = $upstatement_routes->router->match();
 
 			unset( $upstatement_routes->router );
 
-			if ( $route && isset( $route['target'] ) ){
-				if ( isset( $route['params'] ) ){
+			if ( $route && isset( $route['target'] ) ) {
+				if ( isset( $route['params'] ) ) {
 					call_user_func( $route['target'], $route['params'] );
 				} else {
 					call_user_func( $route['target'] );
@@ -44,39 +42,38 @@ class Routes {
 	}
 
 	/**
-	 * @param string   $route             A string to match (ex: 'myfoo')
-	 * @param callable $callback          A function to run, examples:
+	 * @param string   $route             A string to match (ex: 'myfoo').
+	 * @param callable $callback          A function to run, examples:.
 	 *                                    Routes::map('myfoo', 'my_callback_function');
 	 *                                    Routes::map('mybaq', array($my_class, 'method'));
 	 *                                    Routes::map('myqux', function() {
 	 *                                    //stuff goes here
 	 *                                    });
-	 * @param array    $args              ...
-	 * @param bool     $add_to_body_class Whether the slug of the current route should be added to the <body> tag
+	 * @param bool     $add_to_body_class Whether the current route slug should be added to the `<body>` class
 	 */
 	public static function map( $route, $callback, $args = [], $add_to_body_class = true ) {
 		global $upstatement_routes;
 
-		if ( true === $add_to_body_class ){
+		if ( true === $add_to_body_class ) {
 			/** Adds the name or slug of the route to the HTML body tag */
 			add_action( 'init', function ( $classes ) use ( $route ) {
 
 				/** Includes the route page slug in a sanitized form the the <body> ckas */
 				add_filter( 'body_class', function ( $classes ) use ( $route ) {
-					$route = (string) sanitize_title( $route );
+					$route = sanitize_title( $route );
 
-					return (array) array_merge( $classes, [ $route ] );
+					return array_merge( $classes, [ $route ] );
 				} );
 			} );
 		}
 
-		if ( ! isset( $upstatement_routes->router ) ){
+		if ( ! isset( $upstatement_routes->router ) ) {
 			$upstatement_routes->router = new AltoRouter();
 			$site_url                   = get_bloginfo( 'url' );
 			$site_url_parts             = explode( '/', $site_url );
 			$site_url_parts             = array_slice( $site_url_parts, 3 );
 			$base_path                  = implode( '/', $site_url_parts );
-			if ( ! $base_path || strpos( $route, $base_path ) === 0 ){
+			if ( ! $base_path || strpos( $route, $base_path ) === 0 ) {
 				$base_path = '/';
 			} else {
 				$base_path = '/' . $base_path . '/';
@@ -91,11 +88,13 @@ class Routes {
 	}
 
 	/**
-	 * @return string                    A string in a format for AltoRouter
-	 *                                ex: [:my_param]
+	 * @param string $route_string A string combined from the `status_header` filter hook.
+	 *
+	 * @return string $route_string                  A string in a format for AltoRouter
+	 *                                  ex: [:my_param]
 	 */
 	public static function convert_route( $route_string ) {
-		if ( strpos( $route_string, '[' ) > -1 ){
+		if ( strpos( $route_string, '[' ) > - 1 ) {
 			return $route_string;
 		}
 		$route_string = preg_replace( '/(:)\w+/', '/[$0]', $route_string );
@@ -103,77 +102,86 @@ class Routes {
 		$route_string = str_replace( ']]', ']', $route_string );
 		$route_string = str_replace( '[/:', '[:', $route_string );
 		$route_string = str_replace( '//[', '/[', $route_string );
-		if ( strpos( $route_string, '/' ) === 0 ){
+		if ( strpos( $route_string, '/' ) === 0 ) {
 			$route_string = substr( $route_string, 1 );
 		}
+
 		return $route_string;
 	}
 
 	/**
-	 * @param string     $template      A php file to load (ex: 'single.php')
-	 * @param array|bool $tparams       An array of data to send to the php file. Inside the php file
-	 *                                  this data can be accessed via:
-	 *                                  global $params;
-	 * @param int        $status_code   A code for the status (ex: 200)
-	 * @param WP_Query   $query         Use a WP_Query object in the template file instead of
-	 *                                  the default query
-	 * @param int        $priority      The priority used by the "template_include" filter
+	 * @param string        $template    A php file to load (ex: 'single.php').
+	 * @param array|bool    $tparams     An array of data to send to the php file. Inside the php file
+	 *                                   this data can be accessed via:
+	 *                                   global $params.
+	 * @param WP_Query|bool $query       Use a WP_Query object in the template file instead of he default query.
+	 * @param int           $status_code A code for the status (ex: 200).
+	 * @param int           $priority    The priority used by the "template_include" filter.
 	 *
 	 * @return bool
 	 */
 	public static function load( $template, $tparams = false, $query = false, $status_code = 200, $priority = 10 ) {
 		$fullPath = is_readable( $template );
-
-		if ( ! $fullPath ){
+		if ( ! $fullPath ) {
 			$template = locate_template( $template );
 		}
-		if ( $tparams ){
+		if ( $tparams ) {
 			global $params;
 			$params = $tparams;
 		}
-		if ( $status_code ){
+		if ( $status_code ) {
 			add_filter( 'status_header', function ( $status_header, $header, $text, $protocol ) use ( $status_code ) {
 				$text          = get_status_header_desc( $status_code );
 				$header_string = "$protocol $status_code $text";
+
 				return $header_string;
-			},          10, 4 );
-			if ( 404 != $status_code ){
+			},
+						10,
+						4
+			);
+			if ( 404 !== $status_code ) {
 				add_action( 'parse_query', function ( $query ) {
-					if ( $query->is_main_query() ){
+					if ( $query->is_main_query() ) {
 						$query->is_404 = false;
 					}
-				},          1 );
+				},
+							1
+				);
 				add_action( 'template_redirect', function () {
 					global $wp_query;
 					$wp_query->is_404 = false;
-				},          1 );
+				},
+							1
+				);
 			}
 		}
 
-		if ( $query ){
+		if ( $query ) {
 			add_action( 'do_parse_request', function () use ( $query ) {
 				global $wp;
-				if ( is_callable( $query ) ){
+				if ( is_callable( $query ) ) {
 					$query = call_user_func( $query );
 				}
 
-				if ( is_array( $query ) ){
+				if ( is_array( $query ) ) {
 					$wp->query_vars = $query;
 				} elseif ( ! empty( $query ) ) {
 					parse_str( $query, $wp->query_vars );
 				} else {
-					return true;
-				} // Could not interpret query. Let WP try.
+					return true; // Could not interpret query. Let WP try.
+				}
 
 				return false;
-			} );
+			});
 		}
-		if ( $template ){
+		if ( $template ) {
 			add_filter( 'template_include', function ( $t ) use ( $template ) {
 				return $template;
 			},          $priority );
+
 			return true;
 		}
+
 		return false;
 	}
 }
@@ -182,7 +190,6 @@ global $upstatement_routes;
 $upstatement_routes = new Routes();
 
 if ( file_exists( $composer_autoload = __DIR__ . '/vendor/autoload.php' )
-     || file_exists( $composer_autoload = WP_CONTENT_DIR . '/vendor/autoload.php' ) ){
-	require_once( $composer_autoload );
+	 || file_exists( $composer_autoload = WP_CONTENT_DIR . '/vendor/autoload.php' ) ) {
+	require_once $composer_autoload;
 }
-


### PR DESCRIPTION
This pull requests extends Upstament's Router by allowing users whether they'd like to display the sanitized slug of the current route in the <body> tag or not. This may play a big role in CSS and other areas.

Additionally, one parameter has been added to the `map()` function, after `args`, called `add_to_body` which is boolean and set to `true` on default. However, this can be changed individually for any loaded route fike.

Signed-off-by: Kolja Nolte <[kolja.nolte@gmail.com](mailto:kolja.nolte@gmail.com)>