### PR TITLE
Use parse_request instead of do_parse_request action to fix compatibility with Wordpress 6

### DIFF
--- a/Routes.php
+++ b/Routes.php
@@ -131,7 +131,7 @@ class Routes {
 		}
 
 		if ($query) {
-			add_action('do_parse_request', function() use ($query) {
+			add_action('parse_request', function() use ($query) {
 				global $wp;
 				if ( is_callable($query) )
 					$query = call_user_func($query);


### PR DESCRIPTION
Use parse_request instead of do_parse_request action to fix compatibility with Wordpress 6, fix #39

Thanks to @jaybarry for finding the Fix 👍