### PR TITLE
Exclude non-essential files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+* text=auto eol=lf
+
+/bin export-ignore
+/tests export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/.coveralls.yml export-ignore
+/phpunit.xml export-ignore
+/README.md export-ignore
+/readme.txt export-ignore


### PR DESCRIPTION
With the `.gitattributes` file present the users of this package doesn't have to download non-essential files which aren't necessary for the package to function. Such as files used for development (docs, tests, .github, etc).