### PR TITLE
Fixes #46: Incompatible with AltoRouter v2.0.3

### DIFF
--- a/Routes.php
+++ b/Routes.php
@@ -68,8 +68,8 @@ class Routes {
 			$upstatement_routes->router->setBasePath($base_path);
 		}
 		$route = self::convert_route($route);
-		$upstatement_routes->router->map('GET|POST|PUT|DELETE', trailingslashit($route), $callback, $args);
-		$upstatement_routes->router->map('GET|POST|PUT|DELETE', untrailingslashit($route), $callback, $args);
+		$upstatement_routes->router->map('GET|POST|PUT|DELETE', trailingslashit($route), $callback);
+		$upstatement_routes->router->map('GET|POST|PUT|DELETE', untrailingslashit($route), $callback);
 	}
 
 	/**

--- a/Routes.php
+++ b/Routes.php
@@ -50,7 +50,7 @@ class Routes {
 	 *                                  //stuff goes here
 	 *                              });
 	 */
-	public static function map($route, $callback, $args = array()) {
+	public static function map($route, $callback, $name = '') {
 		global $upstatement_routes;
 		if (!isset($upstatement_routes->router)) {
 			$upstatement_routes->router = new AltoRouter();
@@ -68,8 +68,8 @@ class Routes {
 			$upstatement_routes->router->setBasePath($base_path);
 		}
 		$route = self::convert_route($route);
-		$upstatement_routes->router->map('GET|POST|PUT|DELETE', trailingslashit($route), $callback);
-		$upstatement_routes->router->map('GET|POST|PUT|DELETE', untrailingslashit($route), $callback);
+		$upstatement_routes->router->map('GET|POST|PUT|DELETE', trailingslashit($route), $callback, $name);
+		$upstatement_routes->router->map('GET|POST|PUT|DELETE', untrailingslashit($route), $callback, $name);
 	}
 
 	/**


### PR DESCRIPTION
As noted in the issue, the latest version of AltoRouter is incompatible with Upstatement Routes v0.9.1. This PR resolves the error making it compatible.