### PR TITLE
fix: support decimal numbers in route parameters

### DIFF
--- a/Routes.php
+++ b/Routes.php
@@ -59,6 +59,9 @@ class Routes
             return;
         }
         $this->router = new AltoRouter();
+        // Add custom match type that supports dots (for version numbers, semantic versioning, etc.)
+        // This allows routes like /download/:version to match /download/1.5.1
+        $this->router->addMatchTypes(['slug' => '[a-zA-Z0-9._-]+']);
         $site_url = get_bloginfo('url');
         $site_url_parts = explode('/', $site_url);
         $site_url_parts = array_slice($site_url_parts, 3);
@@ -140,19 +143,23 @@ class Routes
      * If the route string already contains [ and ] characters,
      * it is assumed to be in the correct format and is returned unchanged.
      *
+     * Note: Default parameters are converted to [slug:param] to support dots,
+     * underscores, and hyphens in parameter values (e.g., version numbers like 1.5.1).
+     *
      * @internal
      *
      * @param string $route_string a route string with :param style parameters (ex: 'myfoo/:my_param')
      *
      * @return string A string in a format for AltoRouter
-     *                ex: [:my_param]
+     *                ex: [slug:my_param] (supports dots in values)
      */
     public static function convert_route($route_string)
     {
         if (str_contains($route_string, '[')) {
             return $route_string;
         }
-        $route_string = preg_replace('/(:)\w+/', '/[$0]', $route_string);
+        // Convert :param to [slug:param] to support dots, underscores, and hyphens
+        $route_string = preg_replace('/(:)(\w+)/', '/[slug:$2]', $route_string);
         $route_string = str_replace('[[', '[', $route_string);
         $route_string = str_replace(']]', ']', $route_string);
         $route_string = str_replace('[/:', '[:', $route_string);

--- a/Routes.php
+++ b/Routes.php
@@ -61,7 +61,7 @@ class Routes
         $this->router = new AltoRouter();
         // Add custom match type that supports dots (for version numbers, semantic versioning, etc.)
         // This allows routes like /download/:version to match /download/1.5.1
-        $this->router->addMatchTypes(['slug' => '[a-zA-Z0-9._-]+']);
+        $this->router->addMatchTypes(['slug' => '[a-zA-Z0-9._-]++']);
         $site_url = get_bloginfo('url');
         $site_url_parts = explode('/', $site_url);
         $site_url_parts = array_slice($site_url_parts, 3);
@@ -159,7 +159,7 @@ class Routes
             return $route_string;
         }
         // Convert :param to [slug:param] to support dots, underscores, and hyphens
-        $route_string = preg_replace('/(:)(\w+)/', '/[slug:$2]', $route_string);
+        $route_string = preg_replace('/:(\w+)/', '[slug:$1]', $route_string);
         $route_string = str_replace('[[', '[', $route_string);
         $route_string = str_replace(']]', ']', $route_string);
         $route_string = str_replace('[/:', '[:', $route_string);

--- a/Routes.php
+++ b/Routes.php
@@ -59,9 +59,11 @@ class Routes
             return;
         }
         $this->router = new AltoRouter();
-        // Add custom match type that supports dots (for version numbers, semantic versioning, etc.)
-        // This allows routes like /download/:version to match /download/1.5.1
-        $this->router->addMatchTypes(['slug' => '[a-zA-Z0-9._-]++']);
+        // Add a custom match type for named parameters that matches any character
+        // except a slash. Unlike AltoRouter's default param type it allows dots, so
+        // routes like /download/:version match version numbers (1.5.1); unlike an
+        // explicit allow-list it keeps matching Unicode segments (e.g. /blog/café).
+        $this->router->addMatchTypes(['slug' => '[^/]++']);
         $site_url = get_bloginfo('url');
         $site_url_parts = explode('/', $site_url);
         $site_url_parts = array_slice($site_url_parts, 3);

--- a/tests/RoutesTest.php
+++ b/tests/RoutesTest.php
@@ -370,6 +370,28 @@ class RoutesTest extends Integration_Test_Case
 		$this->assertCount(1, $matches);
 	}
 
+	public function testRouteWithUnicodeParameter()
+	{
+		// A named parameter must still match Unicode segments (accented characters,
+		// etc.) — the slug match type excludes only slashes, so it does not regress
+		// non-ASCII URLs like /blog/café. Raised in review of #52.
+		global $matches;
+		$matches = [];
+		Routes::map(
+			'blog/:slug',
+			function ($params) {
+				global $matches;
+				$matches = [];
+				if ('café' === $params['slug']) {
+					$matches[] = true;
+				}
+			}
+		);
+		$this->get(home_url('/blog/café'));
+		$this->matchRoutes();
+		$this->assertCount(1, $matches);
+	}
+
 	public function matchRoutes()
 	{
 		Routes::get_instance()->match_current_request();

--- a/tests/RoutesTest.php
+++ b/tests/RoutesTest.php
@@ -353,7 +353,6 @@ class RoutesTest extends Integration_Test_Case
 	public function testRouteWithDecimalParameter()
 	{
 		// Test for issue #45: routes with decimal numbers (e.g., version numbers like 1.5.1)
-		$phpunit = $this;
 		global $matches;
 		$matches = [];
 		Routes::map(
@@ -368,7 +367,7 @@ class RoutesTest extends Integration_Test_Case
 		);
 		$this->get(home_url('/download/1.5.1'));
 		$this->matchRoutes();
-		$this->assertEquals(1, count($matches));
+		$this->assertCount(1, $matches);
 	}
 
 	public function matchRoutes()

--- a/tests/RoutesTest.php
+++ b/tests/RoutesTest.php
@@ -350,6 +350,27 @@ class RoutesTest extends Integration_Test_Case
 		$this->assertEquals(1, count($matches));
 	}
 
+	public function testRouteWithDecimalParameter()
+	{
+		// Test for issue #45: routes with decimal numbers (e.g., version numbers like 1.5.1)
+		$phpunit = $this;
+		global $matches;
+		$matches = [];
+		Routes::map(
+			'download/:version',
+			function ($params) {
+				global $matches;
+				$matches = [];
+				if ('1.5.1' === $params['version']) {
+					$matches[] = true;
+				}
+			}
+		);
+		$this->get(home_url('/download/1.5.1'));
+		$this->matchRoutes();
+		$this->assertEquals(1, count($matches));
+	}
+
 	public function matchRoutes()
 	{
 		Routes::get_instance()->match_current_request();


### PR DESCRIPTION
Routes with parameters like :version now correctly match decimal numbers such as 1.5.1 and semantic version strings.

Previously, a route like `Routes::map('download/:version', callback);` would work with `/download/release` but not `/download/1.5.1`.

## Root Cause
AltoRouter's default parameter pattern excludes dots.

## Solution
Define custom 'slug' match type with `[a-zA-Z0-9._-]+` for all default route parameters.

## Changes
- Add custom 'slug' match type to AltoRouter in `ensure_router()`
- Modify `convert_route()` to use `[slug:param]` instead of `[:param]`
- Add `testRouteWithDecimalParameter()` test case
- Update docblock comments

Backward compatible: Existing routes continue to work unchanged.

## Changelog
- Add custom 'slug' match type to support dots in route parameters
- Modify parameter conversion to use [slug:param]
- Add test case for decimal parameters

## Testing
- Added `testRouteWithDecimalParameter()` test for `/download/1.5.1`
- Manual verification confirms routes with decimal numbers now work

## Credits
Thanks to @thisismyurl (AI-assisted identification and testing)

Closes #45