### PR TITLE
Fix: Canonical redirects hijacking matched routes (#13)

### DIFF
--- a/Routes.php
+++ b/Routes.php
@@ -255,6 +255,13 @@ class Routes
                 $priority
             );
 
+            // Prevent WordPress's own canonical redirect logic from hijacking a matched
+            // route. This most commonly happens when the requested slug also matches an
+            // attachment: WordPress will otherwise redirect straight to the raw upload
+            // file via `redirect_canonical()` before `template_include` ever runs.
+            // @see https://github.com/Upstatement/routes/issues/13
+            add_filter('redirect_canonical', '__return_false');
+
             return true;
         }
 

--- a/tests/RoutesTest.php
+++ b/tests/RoutesTest.php
@@ -392,6 +392,98 @@ class RoutesTest extends Integration_Test_Case
 		$this->assertCount(1, $matches);
 	}
 
+	public function testRouteSurvivesAttachmentRedirect()
+	{
+		// Regression test for issue #13: WordPress redirects any request that resolves
+		// to an attachment straight to the raw upload file, since attachment pages are
+		// disabled by default (`wp_attachment_pages_enabled`). If the requested slug
+		// also matches a mapped route, that redirect must not hijack the route.
+		$attachment_id = $this->factory->attachment->with_image()->create(
+			[
+				'post_name' => 'books',
+				'post_title' => 'Books',
+			]
+		);
+
+		global $matches;
+		$matches = [];
+
+		Routes::map(
+			'books',
+			function () use ($attachment_id) {
+				global $matches;
+				$matches = [];
+				$matches[] = true;
+
+				// Force the main query to resolve as the attachment, mirroring what
+				// WordPress's own request parsing can produce for a colliding slug.
+				Routes::load(
+					__DIR__ . '/Supports/single.php',
+					false,
+					[
+						'attachment' => 'books',
+						'attachment_id' => $attachment_id,
+					]
+				);
+			}
+		);
+
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$_SERVER['REQUEST_URI'] = '/books/';
+		$this->matchRoutes();
+
+		$response = $this->get(home_url('/books/'));
+
+		$response->assertOk();
+		$this->assertEquals(1, count($matches));
+	}
+
+	public function testUnmatchedRouteDoesNotAffectCanonicalRedirects()
+	{
+		// Sanity check for the fix above: Routes must only cancel WordPress's canonical
+		// redirect when a route has actually matched and rendered a template. Regular
+		// WordPress routing -- like redirecting a legacy ?p=123 link to its canonical
+		// permalink -- must keep working untouched when no route matches at all.
+		$post_id = $this->factory->post->create(['post_title' => 'Hello World']);
+
+		// No Routes::map() call in this test, so match_current_request() is a no-op.
+		$this->matchRoutes();
+
+		$response = $this->get(home_url('/?p=' . $post_id));
+
+		$response->assertRedirect(get_permalink($post_id));
+	}
+
+	public function testMatchedRouteWithoutLoadDoesNotAffectCanonicalRedirects()
+	{
+		// A route can match and run its callback without ever calling Routes::load()
+		// (e.g. it only performs a side effect). Since no template was set, the fix
+		// must not touch WordPress's canonical redirect handling for that request.
+		$post_id = $this->factory->post->create(['post_title' => 'Hello World']);
+
+		global $matches;
+		$matches = [];
+
+		Routes::map(
+			'no-op',
+			function () {
+				global $matches;
+				$matches = [];
+				$matches[] = true;
+			}
+		);
+
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$_SERVER['REQUEST_URI'] = '/no-op/';
+		$this->matchRoutes();
+
+		$this->assertEquals(1, count($matches));
+
+		$response = $this->get(home_url('/?p=' . $post_id));
+
+		$response->assertRedirect(get_permalink($post_id));
+	}
+
 	public function matchRoutes()
 	{
 		Routes::get_instance()->match_current_request();

--- a/tests/RoutesTest.php
+++ b/tests/RoutesTest.php
@@ -435,7 +435,7 @@ class RoutesTest extends Integration_Test_Case
 		$response = $this->get(home_url('/books/'));
 
 		$response->assertOk();
-		$this->assertEquals(1, count($matches));
+		$this->assertCount(1, $matches);
 	}
 
 	public function testUnmatchedRouteDoesNotAffectCanonicalRedirects()
@@ -477,7 +477,7 @@ class RoutesTest extends Integration_Test_Case
 		$_SERVER['REQUEST_URI'] = '/no-op/';
 		$this->matchRoutes();
 
-		$this->assertEquals(1, count($matches));
+		$this->assertCount(1, $matches);
 
 		$response = $this->get(home_url('/?p=' . $post_id));
 


### PR DESCRIPTION

## Problem

When a mapped route's slug happened to match the slug of a media attachment (e.g. an image), WordPress would redirect the request straight to the raw upload file instead of rendering the route.

**Root cause:** WordPress's `redirect_canonical()` runs on `template_redirect` and issues a `301` to the raw attachment file whenever the resolved main query `is_attachment()` is true — this is expected behavior since attachment pages are disabled by default (`wp_attachment_pages_enabled`). The problem is that this redirect fires (and `exit`s) *before* the `template_include` filter that `Routes::load()` registers ever runs, so a matched route gets silently overridden.

## Fix

`Routes::load()` now cancels WordPress's canonical redirect via the documented `redirect_canonical` filter (`add_filter('redirect_canonical', '__return_false')`) whenever it successfully sets up a template. Once a route has matched and is rendering a response, it should always take full control — WordPress's own canonical/attachment redirect logic should no longer have a say.

This only applies when a route actually resolves to a template via `Routes::load()`; requests that don't match any route, or that match a route which never calls `Routes::load()`, are completely unaffected.

## Tests

- `testRouteSurvivesAttachmentRedirect` — reproduces the original bug: creates a colliding attachment, maps a route to the same slug, forces the main query to resolve as that attachment, and asserts the response is `200` (not a `301` to the raw file). Confirmed this test fails without the fix.
- `testUnmatchedRouteDoesNotAffectCanonicalRedirects` — sanity check that regular WordPress canonical redirects (e.g. legacy `?p=123` links) still work when no route matches at all.
- `testMatchedRouteWithoutLoadDoesNotAffectCanonicalRedirects` — sanity check that a route matching and running its callback without calling `Routes::load()` doesn't affect canonical redirects either.

All 25 tests pass, verified stable across multiple random test orderings.

## Files changed

- `Routes.php` — the fix
- `tests/RoutesTest.php` — regression + sanity tests

Fixes #13

