### PR TITLE
chore(release): 1.0.0-rc.1

### DIFF
--- a/Routes.php
+++ b/Routes.php
@@ -18,7 +18,7 @@ class Routes
     /**
      * The version of the library.
      */
-    public static $version = '1.0.0'; // x-release-please-version
+    public static $version = '1.0.0-rc.1'; // x-release-please-version
     /**
      * The AltoRouter instance used to match the current request to the defined routes.
      */


### PR DESCRIPTION
## Summary

Promotes `1.0.0-beta.2` to the first **release candidate**, `1.0.0-rc.1`.

- Bumps `Routes::\$version` from `1.0.0` → `1.0.0-rc.1` (release-please marker preserved).
- **No functional changes** since `beta.2` — `beta.2` sits exactly on the `master` commit this branches from. This is a promotion to signal feature freeze ahead of the 1.0.0 stable release.

## Release plan (after merge)

1. Confirm CI is green on `master`.
2. Tag `1.0.0-rc.1` on `master`.
3. Publish a GitHub **pre-release** with notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)