### PR TITLE
chore(release): 1.0.0-rc.2

### DIFF
--- a/Routes.php
+++ b/Routes.php
@@ -18,7 +18,7 @@ class Routes
     /**
      * The version of the library.
      */
-    public static $version = '1.0.0-rc.1'; // x-release-please-version
+    public static $version = '1.0.0-rc.2'; // x-release-please-version
     /**
      * The AltoRouter instance used to match the current request to the defined routes.
      */


### PR DESCRIPTION
## Summary

Second **release candidate** for 1.0.0.

- Bumps `Routes::\$version` from `1.0.0-rc.1` → `1.0.0-rc.2` (release-please marker preserved).
- Unlike `rc.1` (which was byte-identical to `beta.2`), this candidate includes the canonical-redirect hijack fix (**#53**) now on `master`.

## Plan

Soak for ~1 week, then promote to `1.0.0` stable if no blockers surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)