### PR TITLE
chore(release): 1.0.0-rc.2

### DIFF
--- a/Routes.php
+++ b/Routes.php
@@ -18,7 +18,7 @@ class Routes
     /**
      * The version of the library.
      */
-    public static $version = '1.0.0-rc.1'; // x-release-please-version
+    public static $version = '1.0.0-rc.2'; // x-release-please-version
     /**
      * The AltoRouter instance used to match the current request to the defined routes.
      */


### PR DESCRIPTION
## Summary

Release candidate carrying the canonical-redirect hijack fix (**#53**).

`1.0.0-rc.1` was published to Packagist against the pre-#53 commit (`431f135`) and, per Packagist's version immutability, cannot be changed. So the fix ships as a new immutable version rather than a re-tag.

- Bumps `Routes::\$version` `1.0.0-rc.1` → `1.0.0-rc.2` (release-please marker preserved).
- `master` already contains #53; this only updates the version string to match the new tag.

## Plan after merge

Tag `1.0.0-rc.2` on `master`, soak ~1 week, then promote to `1.0.0` stable if no blockers surface. `rc.1` remains published but superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)