### PR TITLE
chore(release): 1.0.0

### DIFF
--- a/Routes.php
+++ b/Routes.php
@@ -18,7 +18,7 @@ class Routes
     /**
      * The version of the library.
      */
-    public static $version = '1.0.0-rc.2'; // x-release-please-version
+    public static $version = '1.0.0'; // x-release-please-version
     /**
      * The AltoRouter instance used to match the current request to the defined routes.
      */


### PR DESCRIPTION
Promotes `1.0.0-rc.2` to the stable **1.0.0** release.

## What's in this PR

A single-line bump of `Routes::$version` from `1.0.0-rc.2` to `1.0.0`. Nothing else.

## Why now

`1.0.0-rc.2` was published on 2026-07-11 with a planned soak of ~1 week. It has now soaked for 17 days with no blockers reported.

- `master` is **identical** to the `1.0.0-rc.2` tag — zero commits landed since it was cut, so the code shipping as 1.0.0 is byte-for-byte what has been under test.
- CI is green on that commit (PHP lint, Rector, unit tests).
- No open PRs. The one open issue (#11, *Make more AltoRouter options available*) is a `help wanted` enhancement, not a 1.0 blocker.

## Verified

- [x] `Routes::$version` is the only place the version lives — the WP plugin header was removed in c39436c, and `composer.json` intentionally has no `version` key (Packagist infers it from the git tag).
- [x] No test asserts against `Routes::$version` (the `version` hits in `tests/RoutesTest.php` are a route parameter named `:version`).
- [x] README needs no rc-era edits; its "Upgrading to 1.x" section is already written for the stable release.

## After merge

Tag `1.0.0` on `master` (no `v` prefix, matching every prior tag), push it, and publish the GitHub release as a **full release** rather than a pre-release — which will move GitHub's "Latest" label off `0.10.0` for the first time since April.

⚠️ Packagist makes published tags immutable, so the tag push is the point of no return. Any post-tag fix has to ship as `1.0.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)