### PR TITLE
Support named routes and optional route parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Routes::map('blog/:name/page/:pg', function($params){
 
 ## map
 
-`Routes::map($pattern, $callback)`
+`Routes::map($pattern, $callback, $name = '')`
 
 ### Usage
 
@@ -181,6 +181,21 @@ page/:pagenum
 my-users/:userid/edit
 ```
 
+**Optional parameters**
+
+End a parameter with `?` to make it optional, so one route can serve the request with and without that segment:
+
+```php
+<?php
+Routes::map('events/:event?', function($params){
+	if (isset($params['event'])) {
+		// /events/my-gig
+	} else {
+		// /events
+	}
+});
+```
+
 `$callback`
 A function that should fire when the pattern matches the request. Callback takes one argument which is an array of the parameters passed in the URL.
 
@@ -190,6 +205,43 @@ So in this example: `'info/:name/page/:pg'`, $params would have data for:
 - `$data['pg']`
 
 ... which you can use in the callback function as a part of your query
+
+The array is always passed, so a route with no parameters — or one whose optional parameter was left out of the request — calls the callback with an empty array rather than no argument at all.
+
+`$name`
+An optional name for the route, which you can pass to `Routes::url()` to build the route's URL somewhere else in your theme:
+
+```php
+<?php
+Routes::map('my-users/:userid/edit', 'my_callback_function', 'user-edit');
+```
+
+---
+
+## url
+
+`Routes::url($name, $params = [])`
+
+Builds the path of a route that was mapped with a name, filling in its parameters. Handy in a template, so links are generated from the route definition instead of being written out by hand:
+
+```php
+<?php
+/* functions.php */
+Routes::map('my-users/:userid/edit', 'my_callback_function', 'user-edit');
+
+/* somewhere in your theme */
+echo Routes::url('user-edit', array('userid' => 123)); // /my-users/123/edit
+```
+
+### Arguments
+
+`$name` (required)
+The name the route was mapped with. A name that was never mapped throws a `RuntimeException`.
+
+`$params`
+An array of values for the route's parameters, keyed by parameter name. An optional parameter you leave out is dropped from the path.
+
+The returned path is relative to the site root and already includes the subdirectory WordPress is installed under, if any, so it can go straight into an `href`.
 
 ---
 

--- a/Routes.php
+++ b/Routes.php
@@ -25,6 +25,16 @@ class Routes
     protected ?AltoRouter $router = null;
 
     /**
+     * The routes that were mapped with a name, keyed by that name.
+     *
+     * Kept on the instance rather than only inside AltoRouter so that url() can
+     * still generate a path after match_current_request() has released the router.
+     *
+     * @var array<string, string>
+     */
+    private array $named_routes = [];
+
+    /**
      * Private constructor to enforce the singleton pattern.
      *
      * Adds the match_current_request function to the init and wp_loaded hooks,
@@ -64,12 +74,21 @@ class Routes
         // routes like /download/:version match version numbers (1.5.1); unlike an
         // explicit allow-list it keeps matching Unicode segments (e.g. /blog/café).
         $this->router->addMatchTypes(['slug' => '[^/]++']);
+        $this->router->setBasePath($this->base_path());
+    }
+
+    /**
+     * Returns the path WordPress is installed under, wrapped in slashes.
+     * ex: '/' for a root install, '/blog/' for a subdirectory install.
+     */
+    private function base_path(): string
+    {
         $site_url = get_bloginfo('url');
         $site_url_parts = explode('/', $site_url);
         $site_url_parts = array_slice($site_url_parts, 3);
         $base_path = implode('/', $site_url_parts);
-        $base_path = $base_path ? '/' . trim($base_path, '/') . '/' : '/';
-        $this->router->setBasePath($base_path);
+
+        return $base_path ? '/' . trim($base_path, '/') . '/' : '/';
     }
 
     /**
@@ -88,7 +107,11 @@ class Routes
         $this->router = null;
 
         if ($route && isset($route['target'])) {
-            call_user_func($route['target'], ...array_filter([$route['params'] ?? null]));
+            // Always hand the callback its parameters, even when the matched route
+            // has none or its optional parameters were absent from the request.
+            // Dropping the argument makes callbacks declared as function ($params)
+            // -- the form used throughout the README -- fatal on those requests.
+            call_user_func($route['target'], $route['params'] ?? []);
         }
     }
 
@@ -135,8 +158,54 @@ class Routes
         $instance = self::get_instance();
         $instance->ensure_router();
         $route = self::convert_route($route);
-        $instance->router->map('GET|POST|PUT|DELETE|HEAD', trailingslashit($route), $callback, $name);
-        $instance->router->map('GET|POST|PUT|DELETE|HEAD', untrailingslashit($route), $callback, $name);
+        $unslashed = untrailingslashit($route);
+        // A route is mapped in both slash variants so it matches either way, but only
+        // one of them may carry the name: AltoRouter rejects a name it has already
+        // seen, so naming both would throw on every named route.
+        $instance->router->map('GET|POST|PUT|DELETE|HEAD', trailingslashit($route), $callback);
+        $instance->router->map('GET|POST|PUT|DELETE|HEAD', $unslashed, $callback, $name);
+
+        if ($name) {
+            $instance->named_routes[$name] = $unslashed;
+        }
+    }
+
+    /**
+     * Generates the path of a route that was mapped with a name.
+     *
+     * @api
+     *
+     * @param string $name   the name given as map()'s third argument
+     * @param array  $params values for the route's named parameters, keyed by
+     *                       parameter name (ex: ['userid' => 123])
+     *
+     * @return string A path relative to the site root, including the subdirectory
+     *                WordPress is installed under, if any. Optional parameters that
+     *                are not supplied are left out.
+     *
+     * @throws RuntimeException if no route was mapped under that name
+     *
+     * @example
+     * ```php
+     * Routes::map('my-users/:userid/edit', 'my_callback_function', 'user-edit');
+     * $href = Routes::url('user-edit', ['userid' => 123]); // '/my-users/123/edit'
+     * ```
+     */
+    public static function url($name, $params = [])
+    {
+        $instance = self::get_instance();
+
+        if (!isset($instance->named_routes[$name])) {
+            throw new RuntimeException("Route '{$name}' does not exist.");
+        }
+
+        // Generating from a dedicated AltoRouter instance keeps reverse routing
+        // available after match_current_request() has released the matching one.
+        $generator = new AltoRouter();
+        $generator->setBasePath($instance->base_path());
+        $generator->map('GET', $instance->named_routes[$name], null, $name);
+
+        return $generator->generate($name, $params);
     }
 
     /**

--- a/tests/RoutesTest.php
+++ b/tests/RoutesTest.php
@@ -484,6 +484,116 @@ class RoutesTest extends Integration_Test_Case
 		$response->assertRedirect(get_permalink($post_id));
 	}
 
+	public function testNamedRouteMatchesRequest()
+	{
+		// Regression test for issue #11: map() registered the same name on both slash
+		// variants of the route, and AltoRouter refuses a name it has already seen, so
+		// the documented third argument threw "Can not redeclare route" on every use.
+		global $matches;
+		$matches = [];
+		Routes::map(
+			'named-artist/:artist',
+			function ($params) {
+				global $matches;
+				$matches = [];
+				if ('bowie' === $params['artist']) {
+					$matches[] = true;
+				}
+			},
+			'named-artist'
+		);
+		$this->get(home_url('/named-artist/bowie'));
+		$this->matchRoutes();
+		$this->assertCount(1, $matches);
+	}
+
+	public function testUrlGeneratesPathForNamedRoute()
+	{
+		Routes::map('named-users/:userid/edit', function ($params) {}, 'named-user-edit');
+
+		$this->assertSame(
+			wp_parse_url(home_url('/named-users/123/edit'), PHP_URL_PATH),
+			Routes::url('named-user-edit', ['userid' => 123])
+		);
+	}
+
+	public function testUrlGeneratesPathAfterRequestHasBeenMatched()
+	{
+		// match_current_request() releases the AltoRouter instance, but a template
+		// rendered later in the same request still has to be able to build the URL.
+		Routes::map('named-events/:event', function ($params) {}, 'named-event');
+		$this->get(home_url('/named-events/gig'));
+		$this->matchRoutes();
+
+		$this->assertSame(
+			wp_parse_url(home_url('/named-events/gig'), PHP_URL_PATH),
+			Routes::url('named-event', ['event' => 'gig'])
+		);
+	}
+
+	public function testUrlLeavesOutAnAbsentOptionalParameter()
+	{
+		Routes::map('named-archive/:year?', function ($params) {}, 'named-archive');
+
+		$this->assertSame(
+			wp_parse_url(home_url('/named-archive/2026'), PHP_URL_PATH),
+			Routes::url('named-archive', ['year' => 2026])
+		);
+		$this->assertSame(
+			wp_parse_url(home_url('/named-archive/'), PHP_URL_PATH),
+			Routes::url('named-archive')
+		);
+	}
+
+	public function testUrlThrowsForAnUnknownRouteName()
+	{
+		$this->expectException(RuntimeException::class);
+
+		Routes::url('a-route-that-was-never-mapped');
+	}
+
+	public function testOptionalParameterCallbackRunsWhenTheValueIsAbsent()
+	{
+		// Regression test for issue #11: AltoRouter's optional parameter syntax already
+		// matched, but an absent value left the params array empty and the callback was
+		// then called with no argument at all, so the function ($params) callback form
+		// the README documents died with an ArgumentCountError.
+		global $matches;
+		$matches = [];
+		Routes::map(
+			'optional-events/:event?',
+			function ($params) {
+				global $matches;
+				$matches = [];
+				$matches[] = $params;
+			}
+		);
+		$this->get(home_url('/optional-events'));
+		$this->matchRoutes();
+
+		$this->assertCount(1, $matches);
+		$this->assertSame([], $matches[0]);
+	}
+
+	public function testOptionalParameterCallbackReceivesTheValueWhenPresent()
+	{
+		global $matches;
+		$matches = [];
+		Routes::map(
+			'optional-shows/:show?',
+			function ($params) {
+				global $matches;
+				$matches = [];
+				$matches[] = $params;
+			}
+		);
+		$this->get(home_url('/optional-shows/ziggy'));
+		$this->matchRoutes();
+
+		$this->assertCount(1, $matches);
+		$this->assertSame(['show' => 'ziggy'], $matches[0]);
+	}
+
 	public function matchRoutes()
 	{
 		Routes::get_instance()->match_current_request();


### PR DESCRIPTION
This PR proposes making named routes and optional route parameters work end to end, so that `Routes::map()`'s documented `$name` argument stops throwing, the `url()` method its docblock points at actually exists, and a route whose optional parameter is absent still reaches its callback (Fixes #11). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/395. You can sign in with your GitHub ID to claim ownership of the project.

## What happens on master today

Three things sit between the current code and what #11 asks for. All three reproduce on `eed7560`.

**1. A named route throws before it can ever match.** `map()` registers every route twice — once slashed, once unslashed — and hands `$name` to both. AltoRouter refuses a name it has already seen, so the documented third argument is fatal on first use:

```php
Routes::map('my-users/:userid/edit', 'my_callback_function', 'user-edit');
// RuntimeException: Can not redeclare route 'user-edit'
```

**2. `Routes::url()` does not exist.** `map()`'s docblock says the name "can be used to generate URLs with the url() method", but no such method is defined, so a name has nowhere to be used even once it registers.

**3. An optional parameter that is absent kills the callback.** `:param?` compiles and matches correctly, but when the segment is missing the params array is empty, `array_filter()` then drops it, and the callback is invoked with no argument at all — so the `function ($params)` form used throughout the README dies on exactly the request the optional marker exists to serve:

```php
Routes::map('events/:event?', function ($params) { /* ... */ });
// GET /events -> ArgumentCountError: Too few arguments to function {closure}(), 0 passed and exactly 1 expected
```

The whole reproduction runs in your own suite. Check this branch out, put `Routes.php` back to master, and run the tests this PR adds against it:

```
git checkout upstream/master -- Routes.php
vendor/bin/phpunit --filter '(NamedRoute|Url|Optional)'
```

```
1) RoutesTest::testUrlGeneratesPathForNamedRoute
RuntimeException: Can not redeclare route 'named-user-edit'
2) RoutesTest::testNamedRouteMatchesRequest
RuntimeException: Can not redeclare route 'named-artist'
3) RoutesTest::testOptionalParameterCallbackRunsWhenTheValueIsAbsent
ArgumentCountError: Too few arguments to function RoutesTest::{closure}(), 0 passed and exactly 1 expected
4) RoutesTest::testUrlLeavesOutAnAbsentOptionalParameter
RuntimeException: Can not redeclare route 'named-archive'
5) RoutesTest::testUrlGeneratesPathAfterRequestHasBeenMatched
RuntimeException: Can not redeclare route 'named-event'
6) RoutesTest::testUrlThrowsForAnUnknownRouteName
Failed asserting that exception of type "Error" matches expected exception "RuntimeException". Message was: "Call to undefined method Routes::url()"
```

## What changed

**`map()` names one variant, not both.** Only the unslashed route carries `$name`; both variants are still mapped, so matching with or without a trailing slash is untouched. Two different routes sharing one name still throw, as they should.

**New `Routes::url($name, $params = [])`.** It fills a named route's parameters in and returns a path relative to the site root, including the subdirectory WordPress is installed under, so it drops straight into an `href`. It generates from its own AltoRouter instance, which means reverse routing still works from a template rendered later in the request — after `match_current_request()` has released the instance used for matching. A name that was never mapped throws `RuntimeException` with AltoRouter's own wording, and an optional parameter you leave out is dropped from the path.

**`match_current_request()` always passes the params array.** An empty array is now handed to the callback instead of no argument, which is what makes optional parameters usable.

The router itself stays internal, deliberately: the request in #11 was originally for direct access to the AltoRouter object, and the last comment on the thread argues that handing out the mutable instance makes the compatibility surface of this wrapper hard to control. Passing optional parameter syntax and named routes through a narrow API covers the use case without that. The separate `is_readable()` template-path point raised in the same thread is untouched here — it is a different concern from routing, and `testFullPathRoute` shows you deliberately support templates outside the theme directory.

Backward compatibility: callbacks declaring no argument keep working (PHP ignores the extra argument, and your existing `function () use (...)` route tests cover that path), routes mapped without a name behave exactly as before, and nothing was renamed or removed. `Routes::url()` and the third argument to `map()` are purely additive.

## Verification

`composer test` was run on a clean checkout of master first: 25 tests, 25 green. After the change: 32 tests, 41 assertions, all green, with no existing test edited or removed. The suite runs in random order, so I ran it repeatedly under different seeds.

Six of the seven added tests error or fail against master's `Routes.php` (output quoted above) and pass with the change. The seventh, `testOptionalParameterCallbackReceivesTheValueWhenPresent`, passes on master and still passes — it is the control that pins the behaviour that already worked. The added coverage spans a named route matching a request, URL generation before and after the request has been matched, an absent optional parameter both in matching and in generation, an unknown route name, and an optional parameter that is present.

`composer lint` is clean before and after. `composer cs` reports the same four pre-existing formatting hits on `Routes.php` that it reports on master, and no new ones — I kept to the lines this change touches rather than reformatting around them. The `url()` assertions compare against `wp_parse_url(home_url(...), PHP_URL_PATH)` rather than a hard-coded path, so they hold for a subdirectory install as well as a root one; generated paths pick up the same base path that `map()` matches against, e.g. `/blog/my-users/123/edit` for a site installed under `/blog/`.

## How this was managed

This work was tracked on a board built from this repository's own issues and pull requests (54 stories, 6 labels), on the story for this request: [Make more (all?) AltoRouter options available](https://eastagiletracker.com/projects/395/stories/292208). The whole board, including your closed history, is at https://eastagiletracker.com/projects/395.

![board](https://raw.githubusercontent.com/eastagiletracker/routes/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
